### PR TITLE
ci: pass NVD API key to dependency-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,8 @@ jobs:
     permissions:
       contents: read
       security-events: write
+    env:
+      NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
     steps:
       - name: Checkout (manual, no actions)
         timeout-minutes: 10
@@ -103,6 +105,17 @@ jobs:
           echo "PATH=$JAVA_HOME/bin:$PATH" >> $GITHUB_ENV
           java -version
           jq --version
+
+      - name: Write NVD API key to ~/.gradle/gradle.properties
+        run: |
+          mkdir -p ~/.gradle
+          if [ -z "${NVD_API_KEY}" ]; then
+            echo "NVD_API_KEY is not set" >&2
+            exit 1
+          fi
+          ( [ -f ~/.gradle/gradle.properties ] && grep -v '^dependencyCheck\.nvd\.apiKey=' ~/.gradle/gradle.properties || true ) > /tmp/gp || true
+          echo "dependencyCheck.nvd.apiKey=${NVD_API_KEY}" >> /tmp/gp
+          mv /tmp/gp ~/.gradle/gradle.properties
 
       - name: Bootstrap Gradle wrapper if JAR is missing
         timeout-minutes: 5
@@ -152,21 +165,14 @@ jobs:
         timeout-minutes: 15
         run: ./gradlew --no-daemon spotbugsMain spotbugsTest pmdMain pmdTest checkstyleMain checkstyleTest
 
-      # Fix A: NVD Key + Config-Cache hier deaktivieren
-      - name: SCA and SBOM (OWASP DC + CycloneDX)
+      - name: Dependency-Check (with NVD key, config cache disabled)
         timeout-minutes: 15
-        env:
-          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
         run: |
-          set -euo pipefail
-          EXTRA_OPTS=""
-          if [ -n "${NVD_API_KEY:-}" ]; then
-            EXTRA_OPTS="-PdependencyCheck.nvd.apiKey=${NVD_API_KEY}"
-          else
-            echo "WARNING: NVD_API_KEY not set – you may hit rate limits."
-          fi
-          ./gradlew --no-daemon -Dorg.gradle.unsafe.configuration-cache=false \
-            ${EXTRA_OPTS} dependencyCheckAnalyze cyclonedxBom
+          ./gradlew \
+            --no-daemon \
+            --no-configuration-cache \
+            -Dorg.gradle.configuration-cache=false \
+            dependencyCheckAnalyze cyclonedxBom
 
       - name: SAST Semgrep to SARIF
         timeout-minutes: 15


### PR DESCRIPTION
## Summary
- configure `NVD_API_KEY` secret at job level
- write NVD API key to Gradle properties for dependency-check
- run dependency-check with configuration cache disabled

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `./gradlew --no-daemon test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_68c48c46caa88325b5f4051c34b8ee0b